### PR TITLE
Fix for #40

### DIFF
--- a/includes/class-alg-wc-cpp-core.php
+++ b/includes/class-alg-wc-cpp-core.php
@@ -705,6 +705,32 @@ if ( ! class_exists( 'Alg_WC_CPP_Core' ) ) :
 					$this->saved_prices['shop'][ $product_id ] = $return_price;
 				}
 				return $return_price;
+			} else {
+				// will come here when shop behaviour is set to show_in_different (show prices in different currencies ).
+				// and when the product does not have a currency set.
+				switch ( $this->cart_checkout_behaviour ) {
+					case 'convert_first_product':
+					case 'convert_last_product':
+						$shop_currency = get_option( 'woocommerce_currency' );
+
+						$_currency = $this->get_cart_checkout_currency();
+						if ( false !== $_currency && ! isset( $_product->alg_wc_cpp ) && $_currency != $shop_currency ) {
+
+							if ( $do_save_prices && isset( $this->saved_prices['shop'][ $product_id ] ) ) {
+								return $this->saved_prices['shop'][ $product_id ];
+							}
+
+							$exchange_rate          = alg_wc_cpp_get_currency_exchange_rate( $_currency );
+							$currency_exchange_rate = 1 / $exchange_rate;
+
+							$return_price = (float) $price * $currency_exchange_rate;
+							if ( $do_save_prices ) {
+								$this->saved_prices['shop'][ $product_id ] = $return_price;
+							}
+							return $return_price;
+						}
+					break;			
+				}
 			}
 			return $price;
 		}

--- a/includes/class-alg-wc-cpp-core.php
+++ b/includes/class-alg-wc-cpp-core.php
@@ -714,7 +714,7 @@ if ( ! class_exists( 'Alg_WC_CPP_Core' ) ) :
 						$shop_currency = get_option( 'woocommerce_currency' );
 
 						$_currency = $this->get_cart_checkout_currency();
-						if ( false !== $_currency && ! isset( $_product->alg_wc_cpp ) && $_currency != $shop_currency ) {
+						if ( false !== $_currency && ! isset( $_product->alg_wc_cpp ) && $_currency !== $shop_currency ) {
 
 							if ( $do_save_prices && isset( $this->saved_prices['shop'][ $product_id ] ) ) {
 								return $this->saved_prices['shop'][ $product_id ];
@@ -729,7 +729,7 @@ if ( ! class_exists( 'Alg_WC_CPP_Core' ) ) :
 							}
 							return $return_price;
 						}
-					break;			
+						break;
 				}
 			}
 			return $price;


### PR DESCRIPTION
Added new else condition to check for products that do not have the currency set from our plugin & are using the default shop currency.

Tested for Shop behaviour set to "show prices in different currencies" and when cart/checkout behaviour is set to "Convert to currency of last product in cart" or "Convert to currency of first product in cart".

Fix #40