### PR TITLE
Fix exchange rate validation error by replacing extremely small step value with step="any"

### DIFF
--- a/includes/settings/class-alg-wc-cpp-settings-exchange-rates.php
+++ b/includes/settings/class-alg-wc-cpp-settings-exchange-rates.php
@@ -218,7 +218,7 @@ if ( ! class_exists( 'Alg_WC_CPP_Settings_Exchange_Rates' ) ) :
 							'default'           => 1,
 							'type'              => 'number',
 							'custom_attributes' => array(
-								'step' => '0.000000000001',
+								'step' => 'any',
 								'min'  => '0',
 							),
 						),


### PR DESCRIPTION
**Cause**
The input field was using an extremely small step value (1e-12), which caused HTML5 number validation to fail due to floating-point precision issues. As a result, even valid values like 1 were marked invalid, showing the error: Please enter a multiple of 1e-12


**Fix**
Updated the exchange rate number input field to use step="any" instead of an extremely small step value (0.000000000001).

Fix #120 